### PR TITLE
Add Random Arena command, make role view admin-only, event posts into…

### DIFF
--- a/plugins/events/helpers.rb
+++ b/plugins/events/helpers.rb
@@ -73,7 +73,8 @@ module AresMUSH
       character: enactor,
       content_warning: warning)
         
-      Channels.announce_notification(t('events.event_created_notification', :title => title))
+      # Channels.announce_notification(t('events.event_created_notification', :title => title, :name => enactor.name))
+      Manage.announce t('events.event_created_notification', :title => title, :name => enactor.name)
       Events.events_updated
       Achievements.award_achievement(enactor, "event_created")
       return event

--- a/plugins/events/locales/locale_en.yml
+++ b/plugins/events/locales/locale_en.yml
@@ -28,7 +28,7 @@ en:
         
         event_deleted_notification: "Event '%{title}' has been deleted."
         event_updated_notification: "Event '%{title}' has been updated."
-        event_created_notification: "Event '%{title}' has been created."
+        event_created_notification: "Event '%{title}' has been created by %{name}."
         
         event_updated_change: "%{title} updated."
         event_deleted_change: "%{title} deleted."

--- a/plugins/idle/commands/idle_execute_cmd.rb
+++ b/plugins/idle/commands/idle_execute_cmd.rb
@@ -17,7 +17,7 @@ module AresMUSH
       def handle
         report = []
         
-        Manage.announce t('idle.idle_sweep_beginning')
+        # Manage.announce t('idle.idle_sweep_beginning')
         client.program[:idle_queue].map { |id, action| action }.uniq.each do |action|
           ids =  client.program[:idle_queue].select { |id, a| a == action }
           chars = ids.map { |id, action| Character[id] }
@@ -73,7 +73,7 @@ module AresMUSH
           t('idle.idle_post_subject'), 
           t('idle.idle_post_body', :report => report.join("%R")))
         
-          Manage.announce t('idle.idle_sweep_finished')
+        # Manage.announce t('idle.idle_sweep_finished')
       end      
     end
   end

--- a/plugins/idle/helpers.rb
+++ b/plugins/idle/helpers.rb
@@ -16,6 +16,10 @@ module AresMUSH
       ClassTargetFinder.with_a_character(name, client, enactor) do |model|
         Idle.add_to_roster(model, contact)
         client.emit_success t('idle.roster_updated')
+        Forum.system_post(
+          Global.read_config("idle", "idle_category"), 
+          t('idle.roster_opened_subject', :name => model.name), 
+          t('idle.roster_opened_body', :name => model.name))
       end
     end
     
@@ -24,6 +28,8 @@ module AresMUSH
       char.update(idle_state: "Roster")
       char.update(roster_played: char.is_approved?)  # Assume played if approved.
       Idle.idle_cleanup(char, "Roster")
+      Roles.remove_role(char, "approved")
+      Chargen.unsubmit_app(char)
     end
     
     def self.remove_from_roster(char)

--- a/plugins/idle/locales/locale_en.yml
+++ b/plugins/idle/locales/locale_en.yml
@@ -18,7 +18,9 @@ en:
         previously_warned: "Previously idle warned."
         idle_post_subject: "Idled-Out Characters"
         idle_post_body: "The following characters have idled out or are in danger of doing so.%{report}"
-        not_eligible_for_idle: "This command can't be used on NPCs, roster characters and chracters exempt from the idle purge."
+        roster_opened_subject: "Rostered: %{name}"
+        roster_opened_body: "%{name} has been rostered and is now available for applications."
+        not_eligible_for_idle: "This command can't be used on NPCs, roster characters and characters exempt from the idle purge."
         idle_preview: "%{name} last on %{last_on}.  Status: %{status}. Suggested idle action: %{idle_action}.  Last will: %{lastwill}"
         
         lastwill_set: "Last will instructions set."

--- a/plugins/profile/web/character_request_handler.rb
+++ b/plugins/profile/web/character_request_handler.rb
@@ -62,7 +62,9 @@ module AresMUSH
         end
 
         visions = get_visions_list(char.visions)
-        show_visions = enactor.is_admin? || char == enactor
+        if (enactor)
+          show_visions = enactor.is_admin? || char == enactor
+        end
         # End additional Visions code.
 
 

--- a/plugins/randomset/commands/arena_cmd.rb
+++ b/plugins/randomset/commands/arena_cmd.rb
@@ -1,0 +1,56 @@
+module AresMUSH    
+  module Randomset
+    class ArenaCmd
+      include CommandHandler
+
+      # Syntax: arena/random <level>=<badguy level>/<condition level>
+
+      attr_accessor :arena_level, :enemy_level, :condition_level
+
+      def parse_args
+        args = cmd.parse_args(ArgParser.arg1_equals_arg2_slash_arg3)
+        self.arena_level = titlecase_arg(args.arg1)
+        self.enemy_level = titlecase_arg(args.arg2)
+        self.condition_level = downcase_arg(args.arg3)
+      end
+
+      def required_args
+        [self.arena_level, self.enemy_level, self.condition_level]
+      end
+
+      def check_valid_args
+        return t('randomset.arena_error', :level => self.arena_level) if !Randomset.is_valid_arena_level?(self.arena_level)
+        return t('randomset.enemy_error', :level => self.enemy_level) if !Randomset.is_valid_enemy_level?(self.enemy_level)
+        return t('randomset.condition_error', :level => self.condition_level) if !Randomset.is_valid_condition_level?(self.condition_level)
+        return nil
+      end
+  
+      def handle
+        # Build lists of arenas, enemies, and conditions from the config yml files.
+        # Select only the subset of entries which match the appropriate parameters.
+        # Select a single random item from the subset.
+
+        arenas = Global.read_config("randomset", "arenas")
+        arena_list = arenas.sort_by { |arena| arena['level']}.select{ |arena| arena['level'].to_s == self.arena_level }
+        random_arena = arena_list.sample
+
+        enemies = Global.read_config("randomset", "enemies")
+        enemy_list = enemies.sort_by { |enemies| enemies['level']}.select{ |enemies| enemies['level'].to_s == self.enemy_level }
+        random_enemy = enemy_list.sample
+
+        conditions = Global.read_config("randomset", "conditions")
+        condition_list = conditions.sort_by { |conditions| conditions['level']}.select{ |conditions| conditions['level'].to_s == self.condition_level }
+        random_condition = condition_list.sample
+
+        # Construct a hash containing the final result.
+        random_final = { "arena" => {"name" => random_arena['name'], "description" => random_arena['description']}, "enemy" => {"name" => random_enemy['name'], "description" => random_enemy['description']}, "condition" => {"name" => random_condition['name'], "description" => random_condition['description']} }
+
+        # Send to template.
+	template = ArenaTemplate.new random_final, t('randomset.readout_title')
+        client.emit template.render
+
+      end
+
+    end
+  end
+end

--- a/plugins/randomset/helpers.rb
+++ b/plugins/randomset/helpers.rb
@@ -1,0 +1,23 @@
+module AresMUSH
+  module Randomset
+    
+    def self.is_valid_arena_level?(level)
+      return false if !level
+      names = Global.read_config('randomset', 'arenas').map { |a| a['level'].to_s }
+      names.include?(level)
+    end
+    
+    def self.is_valid_enemy_level?(level)
+      return false if !level
+      names = Global.read_config('randomset', 'enemies').map { |a| a['level'].downcase }
+      names.include?(level.downcase)
+    end
+
+    def self.is_valid_condition_level?(level)
+      return false if !level
+      names = Global.read_config('randomset', 'conditions').map { |a| a['level'].downcase }
+      names.include?(level.downcase)
+    end
+
+  end
+end

--- a/plugins/randomset/locales/locale_en.yml
+++ b/plugins/randomset/locales/locale_en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  randomset:
+      readout_title: "Random Arena"
+      arena_error: "%{level} isn't a valid arena level."
+      enemy_error: "%{level} isn't a valid enemy level."
+      condition_error: "%{level} isn't a valid condition level."

--- a/plugins/randomset/randomset.rb
+++ b/plugins/randomset/randomset.rb
@@ -1,0 +1,33 @@
+$:.unshift File.dirname(__FILE__)
+
+module AresMUSH
+     module Randomset
+
+    def self.plugin_dir
+      File.dirname(__FILE__)
+    end
+
+    def self.shortcuts
+      Global.read_config("randomset", "shortcuts")
+    end
+
+    def self.get_cmd_handler(client, cmd, enactor)
+      case cmd.root
+      when "arena"
+        if (cmd.switch_is?("random"))
+          return ArenaCmd
+        end
+      end
+      return nil
+    end
+
+    def self.get_event_handler(event_name)
+      nil
+    end
+
+    def self.get_web_request_handler(request)
+      nil
+    end
+
+  end
+end

--- a/plugins/randomset/templates/randomset_arena.erb
+++ b/plugins/randomset/templates/randomset_arena.erb
@@ -1,0 +1,8 @@
+<%= header %>
+<%= "%xh#{title}%xn%r%r" if title -%>
+<%= "%xh#{subtitle}%xn%r" if subtitle -%>
+<%= text['arena']['name'] %>! <%= text['arena']['description'] %>
+<%= text['enemy']['name'] %>! <%= text['enemy']['description'] %>
+<%= text['condition']['name'] %>! <%= text['condition']['description'] %>
+<%= "#{subfooter}%r" if subfooter -%>
+<%= footer %>

--- a/plugins/randomset/templates/randomset_arena_template.rb
+++ b/plugins/randomset/templates/randomset_arena_template.rb
@@ -1,0 +1,16 @@
+module AresMUSH
+  class ArenaTemplate < ErbTemplateRenderer
+          
+    attr_accessor :text, :title, :subfooter, :subtitle
+    
+    def initialize(text, title = nil, subfooter = nil, subtitle = nil)
+
+      @text = text
+      @title = title
+      @subtitle = subtitle
+      @subfooter = subfooter
+      
+      super File.dirname(__FILE__) + "/randomset_arena.erb"
+    end
+  end
+end

--- a/plugins/roles/commands/roles_cmd.rb
+++ b/plugins/roles/commands/roles_cmd.rb
@@ -8,6 +8,11 @@ module AresMUSH
       def parse_args
         self.name = !cmd.args ? enactor_name : trim_arg(cmd.args)
       end
+
+      def check_can_use
+        return t('dispatcher.not_allowed') if !enactor.is_admin?
+        return nil
+      end
       
       def handle        
         ClassTargetFinder.with_a_character(self.name, client, enactor) do |char|


### PR DESCRIPTION
… a wall announce, and improve idle and roster announcements.

* Random Arena will generate a random set pose based off flavor text that is added in the site's config.
* Roles command is now only usable by admin. Do not permit characters to view the list of roles.
* When an event is created, send a wall announcement instead of a Game channel message. Add the Event creator's name to the message. Other event messages remain on Game.
* Remove wall announcements involved in the idle sweep process, since a bbpost is already made.
* Post to the idle_category forum board when a character is rostered with roster/add.
* Remove the approved role and unsubmit the app of a character, when they are rostered with roster/add. This is to leave the character in a chargennable state for the next player.